### PR TITLE
Fix "reccomended" typo in Homebrew formula dependencies

### DIFF
--- a/Formula/emacs-head@28.rb
+++ b/Formula/emacs-head@28.rb
@@ -167,7 +167,7 @@ class EmacsHeadAT28 < Formula
     depends_on "gmp"       => :build
     depends_on "libjpeg"   => :build
     depends_on "zlib"      => :build
-    depends_on "libgccjit" => :reccomended
+    depends_on "libgccjit" => :recommended
   end
 
   def self.get_resource_url(resource)

--- a/Formula/emacs-head@29.rb
+++ b/Formula/emacs-head@29.rb
@@ -171,7 +171,7 @@ class EmacsHeadAT29 < Formula
     depends_on "gmp"       => :build
     depends_on "libjpeg"   => :build
     depends_on "zlib"      => :build
-    depends_on "libgccjit" => :reccomended
+    depends_on "libgccjit" => :recommended
   end
 
   if build.with? "tree-sitter"

--- a/Formula/emacs-head@30.rb
+++ b/Formula/emacs-head@30.rb
@@ -165,7 +165,7 @@ class EmacsHeadAT30 < Formula
     depends_on "gmp"       => :build
     depends_on "libjpeg"   => :build
     depends_on "zlib"      => :build
-    depends_on "libgccjit" => :reccomended
+    depends_on "libgccjit" => :recommended
   end
 
   if build.with? "tree-sitter"


### PR DESCRIPTION
I just noticed this typo in the Homebrew formulas. It's localized to the
libgccjit dependency.

https://rubydoc.brew.sh/Formula.html#depends_on-class_method

```
:recommended dependencies are built by default. But a --without-... option is
generated to opt-out.
```

```
depends_on "readline" => :recommended
```